### PR TITLE
Updated mustache template and path

### DIFF
--- a/flows/pipeline_RESTAggregation.json
+++ b/flows/pipeline_RESTAggregation.json
@@ -1,7 +1,8 @@
 {
 	"flow": {
 		"name":"Hello aggregation REST API",
-		"disabled": true
+		"disabled": true,
+		"expandRouteProperties": true
 	},
 	"listener": {
 		"type":"rest_listener", 

--- a/flows/pipeline_RESTHello.json
+++ b/flows/pipeline_RESTHello.json
@@ -1,7 +1,8 @@
 {
 	"flow": {
 		"name":"Hello world REST API",
-		"disabled": true
+		"disabled": true,
+		"expandRouteProperties": true
 	},
 	"listener": {
 		"type":"rest_listener", 

--- a/flows/pipeline_RESTtoCSV.json
+++ b/flows/pipeline_RESTtoCSV.json
@@ -18,7 +18,7 @@
 		"type": "csvwriter",
 		"dependencies":["listener"],
 		"headers":["firstname", "lastname"],
-		"path":"{{ESB_DIR}}/json2csv.csv",
+		"path":"{{{ESB_DIR}}}/json2csv.csv",
 		"encoding":"utf8",
 		"timeout":5000
 	},

--- a/flows/pipeline_csvtojson.json
+++ b/flows/pipeline_csvtojson.json
@@ -7,15 +7,15 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path":"{{ESB_DIR}}/in/*.csv",
-		"donePath":"{{ESB_DIR}}/processing"
+		"path":"{{{ESB_DIR}}}/testing/in/*.csv",
+		"donePath":"{{{ESB_DIR}}}/testing/processing"
 	},
 	"route0":{
 		"type": "csvfilereader",
 		"dependencies":["listener"],
 		"rowsPerParse": 10000,
 		"skip_first_row":true,
-        "donePath":"{{ESB_DIR}}/done"
+        "donePath":"{{{ESB_DIR}}}/testing/done"
 	},
 	"route1": {
 		"type":"csvparser",
@@ -26,7 +26,7 @@
 	"output": {
 		"type": "filewriter",
         "dependencies":"route1",
-		"path":"{{ESB_DIR}}/VOO.ndjson",
+		"path":"{{{ESB_DIR}}}/VOO.ndjson",
 		"write_ndjson": true,
 		"append": true,
 		"writeCloseTimeout": 5000,

--- a/flows/pipeline_editojson.json
+++ b/flows/pipeline_editojson.json
@@ -7,24 +7,24 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path":"{{ESB_DIR}}/in/210invoice.x12",
-		"donePath":"{{ESB_DIR}}/processing"
+		"path":"{{{ESB_DIR}}}/testing/in/210invoice.x12",
+		"donePath":"{{{ESB_DIR}}}/testing/processing"
 	},
 	"route0":{
 		"type": "filereader",
 		"dependencies":["listener"],
-        "donePath":"{{ESB_DIR}}/done",
+        "donePath":"{{{ESB_DIR}}}/testing/done",
         "encoding":"utf8"
 	},
 	"route1": {
 		"type":"ediparser",
 		"dependencies":["route0"],
-		"java":"{{process.env.JAVA_HOME}}/bin/java.exe"
+		"java":"{{{process.env.JAVA_HOME}}}/bin/java.exe"
 	},
 	"output": {
 		"type": "filewriter",
         "dependencies":"route1",
-		"path":"{{ESB_DIR}}/210invoice.json",
+		"path":"{{{ESB_DIR}}}/210invoice.json",
 		"prettyJSON": 4,
 		"append": false,
 		"writeCloseTimeout": 5000

--- a/flows/pipeline_editojson2.json
+++ b/flows/pipeline_editojson2.json
@@ -7,13 +7,13 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path":"{{ESB_DIR}}/in/210invoice.x12",
-		"donePath":"{{ESB_DIR}}/processing"
+		"path":"{{{ESB_DIR}}}/testing/in/210invoice.x12",
+		"donePath":"{{{ESB_DIR}}}/testing/processing"
 	},
 	"route0":{
 		"type": "filereader",
 		"dependencies":["listener"],
-        "donePath":"{{ESB_DIR}}/done",
+        "donePath":"{{{ESB_DIR}}}/testing/done",
         "encoding":"utf8"
     },
     "route1":{
@@ -24,19 +24,19 @@
 	"route2": {
 		"type":"ediparser",
 		"dependencies":["route1.1"],
-		"java":"{{process.env.JAVA_HOME}}/bin/java.exe"
+		"java":"{{{process.env.JAVA_HOME}}}/bin/java.exe"
 	},
 	"route3": {
 		"type":"filewriter",
 		"dependencies":["route1.2"],
-		"path":"{{ESB_DIR}}/210invoice_copy.edi",
+		"path":"{{{ESB_DIR}}}/210invoice_copy.edi",
 		"append": false,
 		"writeCloseTimeout": 5000
 	},
 	"output": {
 		"type": "filewriter",
         "dependencies":"route2",
-		"path":"{{ESB_DIR}}/210invoice.json",
+		"path":"{{{ESB_DIR}}}/210invoice.json",
 		"prettyJSON": 4,
 		"append": false,
 		"writeCloseTimeout": 5000

--- a/flows/pipeline_emailFileNotification.json
+++ b/flows/pipeline_emailFileNotification.json
@@ -7,13 +7,13 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path":"{{ESB_DIR}}/in/*",
-		"donePath":"{{ESB_DIR}}/done"
+		"path":"{{{ESB_DIR}}}/testing/in/*",
+		"donePath":"{{{ESB_DIR}}}/testing/done"
 	},
 	"route0":{
 		"type": "js",
 		"dependencies":"listener",
-		"module":"{{ESB_DIR}}/custom/email_custom.js"
+		"module":"{{{ESB_DIR}}}/custom/email_custom.js"
 	},
 	"output": {
 		"type": "email",

--- a/flows/pipeline_imaptofile.json
+++ b/flows/pipeline_imaptofile.json
@@ -21,7 +21,7 @@
 	"output": {
 		"type": "filewriter",
         "dependencies":"listener",
-		"path":"{{ESB_DIR}}/email.json",
+		"path":"{{{ESB_DIR}}}/email.json",
 		"prettyJSON": 4,
 		"append": false,
 		"writeCloseTimeout": 5000

--- a/flows/pipeline_jsonToTSVViaSftp.json
+++ b/flows/pipeline_jsonToTSVViaSftp.json
@@ -7,8 +7,8 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path": "{{ESB_DIR}}/testing/in/json2tsv.tsv",
-		"donePath": "{{ESB_DIR}}/testing/done"
+		"path": "{{{ESB_DIR}}}/testing/in/json2tsv.tsv",
+		"donePath": "{{{ESB_DIR}}}/testing/done"
 	},
     "route1":{
 		"type": "sftpdownload",
@@ -23,12 +23,12 @@
 	"route2": {
 		"type": "mustache",
         "dependencies": "route0",
-        "template": "{{ESB_DIR}}/testing/done/json2tsv.tsv"
+        "template": "{{{ESB_DIR}}}/testing/done/json2tsv.tsv"
 	},
 	"output": {
 		"type": "filewriter",
         "dependencies": "route2",
-		"path": "{{ESB_DIR}}/testing/out/json2tsv.tsv",
+		"path": "{{{ESB_DIR}}}/testing/out/json2tsv.tsv",
 		"append": false,
 		"writeCloseTimeout": 5000,
 		"encoding": "utf8"

--- a/flows/pipeline_jsonToXMLViaMustache.json
+++ b/flows/pipeline_jsonToXMLViaMustache.json
@@ -7,24 +7,24 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path": "{{ESB_DIR}}/testing/in/json2SAP_ORDERS05.json",
-		"donePath": "{{ESB_DIR}}/testing/processing"
+		"path": "{{{ESB_DIR}}}/testing/in/json2SAP_ORDERS05.json",
+		"donePath": "{{{ESB_DIR}}}/testing/processing"
 	},
 	"route0":{
 		"type": "filereader",
 		"dependencies": "listener",
-        "donePath": "{{ESB_DIR}}/testing/done",
+        "donePath": "{{{ESB_DIR}}}/testing/done",
         "encoding": "utf8"
 	},
 	"route1": {
 		"type": "mustache",
         "dependencies": "route0",
-        "template": "{{ESB_DIR}}/testing/json2SAP_ORDERS05.xml"
+        "template": "{{{ESB_DIR}}}/testing/json2SAP_ORDERS05.xml"
 	},
 	"output": {
 		"type": "filewriter",
         "dependencies": "route1",
-		"path": "{{ESB_DIR}}/testing/json2xml_out_SAP_ORDERS05.xml",
+		"path": "{{{ESB_DIR}}}/testing/json2xml_out_SAP_ORDERS05.xml",
 		"append": false,
 		"writeCloseTimeout": 5000,
 		"encoding": "utf8"

--- a/flows/pipeline_multicsvtojsons.json
+++ b/flows/pipeline_multicsvtojsons.json
@@ -7,15 +7,15 @@
 	"listener": {
 		"type":"file", 
 		"isMessageGenerator": true,
-		"path":"{{ESB_DIR}}/in/*^GSPC.csv",
-		"donePath":"{{ESB_DIR}}/processing"
+		"path":"{{{ESB_DIR}}}/testing/in/*^GSPC.csv",
+		"donePath":"{{{ESB_DIR}}}/testing/processing"
 	},
 	"route0":{
 		"type": "csvfilereader",
 		"dependencies":["listener"],
 		"rowsPerParse": 10000,
 		"skip_first_row":true,
-        "donePath":"{{ESB_DIR}}/done"
+        "donePath":"{{{ESB_DIR}}}/testing/done"
 	},
 	"route1": {
 		"type":"csvparser",
@@ -26,7 +26,7 @@
 	"output": {
 		"type": "filewriter",
 		"dependencies":"route1",
-		"interceptor_module":"{{ESB_DIR}}/custom/multipath_interceptor.js",
+		"interceptor_module":"{{{ESB_DIR}}}/custom/multipath_interceptor.js",
 		"interceptor_js":"",
 		"write_ndjson": true,
 		"append": true,

--- a/flows/pipeline_sapWStoJSON.json
+++ b/flows/pipeline_sapWStoJSON.json
@@ -20,7 +20,7 @@
 	"route1": {
 		"type": "filewriter",
 		"dependencies": "route0",
-        "path": "{{ESB_DIR}}/sapIn.json",
+        "path": "{{{ESB_DIR}}}/sapIn.json",
         "prettyJSON": 4,
 		"append": false,
 		"writeCloseTimeout": 5000

--- a/flows/pipeline_sftpJSONToSAPiDoc.json
+++ b/flows/pipeline_sftpJSONToSAPiDoc.json
@@ -9,7 +9,7 @@
 		"type":"sftp", 
 		"isMessageGenerator": true,
 		"path": "/home/tekmonks/in/*.json",
-		"donePath": "{{ESB_DIR}}/testing/processing",
+		"donePath": "{{{ESB_DIR}}}/testing/processing",
 		"remoteDonePath": "/home/tekmonks/done",
 		"host": "[add ip here]",
 		"user": "[add user here]",
@@ -19,14 +19,14 @@
 	"route0":{
 		"type": "filereader",
 		"dependencies": "listener",
-        "donePath": "{{ESB_DIR}}/testing/done",
+        "donePath": "{{{ESB_DIR}}}/testing/done",
         "encoding": "utf8",
 		"path": "{{{message.env.filepath}}}"
 	},
 	"route1": {
 		"type": "mustache",
         "dependencies": "route0",
-        "template": "{{ESB_DIR}}/testing/json2SAP_ORDERS05.xml"
+        "template": "{{{ESB_DIR}}}/testing/json2SAP_ORDERS05.xml"
 	},
 	"output": {
 		"type": "sftpupload",


### PR DESCRIPTION
Issue
The original {{ESB_DIR}} syntax caused HTML escaping of slashes, leading to an invalid path. This resulted in the application attempting to access a non-existent directory.

Path Error: The path was incorrectly specified as {{ESB_DIR}}/in/*.csv, missing the testing directory. This led the application to search for files in the wrong location. This issue is in multiple flows.

Solution
To fix the issue, the Mustache template was changed to {{{ESB_DIR}}}, using triple braces to prevent HTML escaping.
The path was corrected to {{{ESB_DIR}}}/testing/in/*.csv to include the correct directory structure.

This is the mantis for the same
https://tekmonks.mantishub.io/view.php?id=3885

