### PR TITLE
[minor-fix] asb.sh declared to bash scrip instead of sh

### DIFF
--- a/asb.sh
+++ b/asb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"


### PR DESCRIPTION
Issue: asb.sh command failed

Error screenshot:
<img width="420" height="56" alt="image" src="https://github.com/user-attachments/assets/4fad0f91-fabb-44bd-8b86-195ed1a5b9aa" />

Root cause: Script using bash syntax but using sh in shebang 

Fix: changes the shebang to bash

Screenshot after fix:
<img width="338" height="119" alt="image" src="https://github.com/user-attachments/assets/945e2f71-7a3c-4945-9780-46c23b387a0c" />
