### PR TITLE
[fix] routes/filewriter to proper JSON string handling for NDJSONs | [fix/improve] listener/imap.js to properly handle the logout/close IMAP client and also added handling for the full-email failed response or Sigle part downloads

### DIFF
--- a/flows/pipeline_imaptofile.json
+++ b/flows/pipeline_imaptofile.json
@@ -21,9 +21,9 @@
 	"output": {
 		"type": "filewriter",
         "dependencies":"listener",
-		"path":"{{{ESB_DIR}}}/email.json",
-		"prettyJSON": 4,
-		"append": false,
+		"path":"{{{ESB_DIR}}}/email.ndjson",
+		"write_ndjson": true,
+		"append": true,
 		"writeCloseTimeout": 5000
 	}
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,6 +14,7 @@ exports.LISTENERSDIR = path.normalize(rootdir+"/listeners");
 
 exports.ESBCONF = rootdir+"/conf/esb.json";
 exports.LOGSCONF = rootdir+"/conf/log.json";
+exports.IMAPCONF = rootdir+"/conf/imap.json";
 exports.CLUSTERCONF = rootdir+"/conf/cluster.json";
 exports.CRYPTCONF = rootdir+"/conf/crypt.json";
 exports.LOGMAIN = rootdir+"/logs/asb.log.ndjson";

--- a/listeners/imap.js
+++ b/listeners/imap.js
@@ -7,6 +7,7 @@
  */
 
 const {ImapFlow} = require("imapflow");
+const conf = require(ASBCONSTANTS.IMAPCONF);
 const crypt = require(`${ASBCONSTANTS.LIBDIR}/crypt.js`);
 const asbutils = require(`${ASBCONSTANTS.LIBDIR}/utils.js`);
 
@@ -23,7 +24,11 @@ exports.start = async (routeName, imapnode, messageContainer, _message) => {
     try {
         const imapPassword = crypt.decrypt(imapnode.password); 
         imapClient = new ImapFlow({host: imapnode.host, port: imapnode.port, secure: imapnode.tls,
-            auth: {user: imapnode.user, pass: imapPassword}});
+            socketTimeout: imapnode.socketTimeout || conf.socketTimeout,  // milliseconds of connection inactivity to allow before dropping
+            greetingTimeout: imapnode.greetingTimeout || conf.greetingTimeout,  // milliseconds to wait for the initial server greeting after TCP completion
+            connectionTimeout: imapnode.connectionTimeout || conf.connectionTimeout,  // milliseconds of overall connection timeout
+            auth: { user: imapnode.user, pass: imapPassword }
+        });
         await imapClient.connect(); isConnected = true;
         imap_mailbox_lock = await imapClient.getMailboxLock(imapnode.mailbox || "INBOX");
 
@@ -40,21 +45,21 @@ exports.start = async (routeName, imapnode, messageContainer, _message) => {
             ASBLOG.info(`"[IMAP_LISTENER] Email matching filtering criteria - ${JSON.stringify(emailUnread.envelope)}`);
         } 
 
+        const partsToInject = imapnode.partsToInject || [];
         for (const emailToInject of emailsToFetch) {
-            const partsToDownload = _getParts(emailToInject.bodyStructure.childNodes);
-            const fullEmail = await imapClient.downloadMany(emailToInject.seq, Object.keys(partsToDownload));
-            if (!fullEmail) throw new Error(`Unable to download the message ${JSON.stringify(emailUnread.envelope)}`);
+            const {partsToDownload, fullEmail} = await _downloadEmailParts(imapClient, emailToInject);
+            if (!fullEmail || fullEmail.response === false) throw new Error(`Unable to download the message ${JSON.stringify(emailToInject.envelope)}`);
         
             const message = MESSAGE_FACTORY.newMessageAllocSafe();
             if (!message) throw new Error(`Unable to create a new message to inject.`);
-            if (imapnode.partsToInject.includes("envelope")) message.content.envelope = asbutils.clone(emailToInject.envelope);
+            if (partsToInject.includes("envelope")) message.content.envelope = asbutils.clone(emailToInject.envelope);
             for (const [key, part] of Object.entries(fullEmail)) {
                 if (!_isAttachment(part)) { // extract email texts 
-                    if (part.meta.contentType.toLowerCase() == "text/html" && imapnode.partsToInject.includes("html"))
+                    if (part.meta.contentType.toLowerCase() == "text/html" && partsToInject.includes("html"))
                         message.content.htmls = [part.content.toString('utf8'), ...(message.content.htmls||[])];
-                    if (part.meta.contentType.toLowerCase() == "text/plain" && imapnode.partsToInject.includes("text"))
+                    if (part.meta.contentType.toLowerCase() == "text/plain" && partsToInject.includes("text"))
                         message.content.texts = [part.content.toString('utf8'), ...(message.content.texts||[])];
-                } else if (imapnode.partsToInject.includes("attachments")) {    // extract email attachments
+                } else if (partsToInject.includes("attachments")) {    // extract email attachments
                     const attachmentThisPart = {contentType: part.meta.contentType, filename: part.meta.filename, 
                         data: Buffer.from(part.content).toString("base64"), 
                         _imap_part_size: partsToDownload[key].size, encoding: "base64"};
@@ -67,8 +72,17 @@ exports.start = async (routeName, imapnode, messageContainer, _message) => {
             ASBLOG.info(`[IMAP_LISTENER] Injected message with timestamp: ${message.timestamp}`); 
         }
     } catch (err) {
-        ASBLOG.error(`[IMAP_LISTENER] IMAP server error for node ${routeName}, the error is ${JSON.stringify(err)}`)
-    } finally { try {if (imap_mailbox_lock) imap_mailbox_lock.release(); if (isConnected && imapClient) await imapClient.logout();} catch (err) {} }
+        ASBLOG.error(`[IMAP_LISTENER] IMAP server error for node ${routeName}, the error is ${err.stack || JSON.stringify(err)}`)
+    } finally {
+        try {
+            if (imap_mailbox_lock) imap_mailbox_lock.release();
+            if (isConnected && imapClient) await imapClient.logout();
+        } catch (err) {
+            ASBLOG.error(`[IMAP_LISTENER] IMAP client logout failed. Trying to close the connection, the error is ${err.stack || JSON.stringify(err)}`);
+            try { if (imapClient) imapClient.close(); ASBLOG.info(`[IMAP_LISTENER] IMAP client connection is successfully closed.`);} 
+            catch (err) { ASBLOG.error(`[IMAP_LISTENER] IMAP closing client connection failed, the error is ${err.stack || JSON.stringify(err)}`); }
+        } 
+    }
 
     imapnode.flow.env[routeName] = {"busy":false};
 }
@@ -82,4 +96,36 @@ function _getParts(childNodes, arraySoFar={}) {
     return arraySoFar;
 }
 
-const _isAttachment = part => (part.meta.disposition?.toLowerCase() == "attachment") || (part.meta.filename);
+const _readStream = async stream => {
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    return Buffer.concat(chunks);
+};
+
+/**
+ * Download the IMAP body data for one email and normalize the result shape.
+ * 
+ * Multipart messages are fetched with `downloadMany()` using the flattened
+ * body structure parts. Single-part messages fall back to `download("1")`,
+ * and the returned stream is converted into a Buffer so the caller can treat
+ * both paths the same way.
+ *
+ * @param {ImapFlow} imapClient The connected IMAP client.
+ * @param {Object} emailToInject The fetched message record from `fetch()`.
+ * @returns {Object} {partsToDownload: Object, fullEmail: Object}} The part size map
+ * and the normalized download result.
+ */
+const _downloadEmailParts = async (imapClient, emailToInject) => {
+    const bodyStructure = emailToInject.bodyStructure || {};
+    if (bodyStructure.childNodes && bodyStructure.childNodes.length) {
+        const partsToDownload = _getParts(bodyStructure.childNodes);
+        return { partsToDownload, fullEmail: await imapClient.downloadMany(emailToInject.seq, Object.keys(partsToDownload)) };
+    }
+
+    const partsToDownload = {1: {size: emailToInject.size || 0}};
+    const singlePart = await imapClient.download(emailToInject.seq, "1");
+    if (!singlePart || singlePart.response == false || !singlePart.content) return {partsToDownload, fullEmail: singlePart};
+    return { partsToDownload, fullEmail: {1: {meta: singlePart.meta, content: await _readStream(singlePart.content)}} };
+};
+
+const _isAttachment = part => part.meta && (part.meta.disposition?.toLowerCase()=="attachment" || part.meta.filename);

--- a/routes/filewriter.js
+++ b/routes/filewriter.js
@@ -17,8 +17,9 @@ exports.start = (routeName, filewriter, messageContainer, message) => {
     if (filewriter.interceptor_js) new Function(["require", "routeName", "filewriter", "messageContainer", "message"], 
         filewriter.interceptor_js)(require, routeName, filewriter, messageContainer, message);
 
-    let output = (message.content instanceof Object ? JSON.stringify(message.content, null, filewriter.prettyJSON) :
-        message.content);
+    let output = (message.content instanceof Object ? (filewriter.prettyJSON ? 
+        JSON.stringify(message.content, null, filewriter.prettyJSON) : JSON.stringify(message.content)) 
+        : message.content);
     if (message.content instanceof Object && filewriter.write_ndjson) output += "\n";   // ndjson format
 
     let fw; let flow = filewriter.flow;


### PR DESCRIPTION
## Issues
1. IMAP listener fails on emails without `childNodes`
   - Single-part emails were treated like multipart messages, which caused `_getParts()` to break because `childNodes` was missing.

2. IMAP `downloadMany()` success check was using the wrong response shape
   - The listener was not checking `fullEmail.response`, causing the parts to be empty and causing the critical error if the download fails
 
3. IMAP client configuration was missing timeout support
   - The listener did not apply configurable socket, greeting, and connection timeouts from IMAP config.

4. Filewriter always pretty-printed JSON output
   - Output serialisation was tied to `prettyJSON`, which made plain JSON output inconsistent unless formatting was explicitly configured.

6. IMAP pipeline output format changed to NDJSON
   - The IMAP-to-file flow now writes append-only NDJSON instead of overwriting a single JSON file.

## Changes
- [`listeners/imap.js`](https://github.com/TekMonksGitHub/ASB/tree/master/listeners/imap.js)
  - Added IMAP timeout settings from `conf/imap.json` when creating the `ImapFlow` client.
  - Reworked email download logic into `_downloadEmailParts()` so multipart messages use `downloadMany()` and single-part messages use `download("1")`.
  - Added stream-to-buffer handling for single-part downloads.
  - Fixed attachment detection to use `part.meta.disposition` correctly.
  - Cleaned up error handling and mailbox logout/close behaviour.

- [`routes/filewriter.js`](https://github.com/TekMonksGitHub/ASB/tree/master/routes/filewriter.js)
  - Changed object serialisation so `prettyJSON` is optional.
  - If `prettyJSON` is set, output is pretty-printed.
  - If `prettyJSON` is not set, output is still JSON stringified instead of relying on default object handling.

- [`lib/constants.js`](https://github.com/TekMonksGitHub/ASB/tree/master/lib/constants.js)
  - Added a new constant: `IMAPCONF`, pointing to `conf/imap.json`.

- [`flows/pipeline_imaptofile.json`](https://github.com/TekMonksGitHub/ASB/tree/master/flows/pipeline_imaptofile.json)
  - Changed the output file from `email.json` to `email.ndjson`.
  - Enabled `write_ndjson`.
  - Changed `append` from `false` to `true`.
